### PR TITLE
Fixing python utf8 errors

### DIFF
--- a/src/scripts/generate_abbrev.qx.py
+++ b/src/scripts/generate_abbrev.qx.py
@@ -54,9 +54,9 @@ def main():
     DATA_FILE = args['data_file'][0]
     OUT_FILE  = args['output_file'][0]
 
-    with open(DATA_FILE, 'r') as data:
+    with open(DATA_FILE, 'r', encoding='utf-8') as data:
         qx = generate_qx(data)
-    with open(OUT_FILE, 'w') as out:
+    with open(OUT_FILE, 'w', encoding='utf-8') as out:
         out.write(qx)
 
 

--- a/src/scripts/test.tmpl2cpp.py
+++ b/src/scripts/test.tmpl2cpp.py
@@ -81,7 +81,7 @@ def generate_tests(test_file):
     """Visszater a kapott fajlbol kinyerheto testesthez tartozo koddal.
     """
     # TODO: atirni try-al!
-    with open(test_file) as file_:
+    with open(test_file, encoding='utf-8') as file_:
         fst_line = file_.readline()
         lines = file_.readlines()
     fst_line = fst_line.lstrip('#')
@@ -121,7 +121,7 @@ def main():
     with open(TMPL_FILE, 'r') as tmpl:
         cpp = generate_cpp(tmpl, tests)
     # kiiras
-    with open(OUT_FILE, 'w') as out:
+    with open(OUT_FILE, 'w', encoding='utf-8') as out:
         out.write(cpp)
 
 


### PR DESCRIPTION
I did this:
```
git clone git@github.com:dlt-rilmta/quntoken.git
cd quntoken/
virtualenv -p python2.7 env
. env/bin/activate
make install
make all
```

on this machine: `Linux matura 4.6.0-rc3-mainline #1 SMP PREEMPT Mon Apr 11 22:40:37 CEST 2016 x86_64 GNU/Linux` with this default python: `Python 2.7.11`

I got this:
```
...
Traceback (most recent call last):
  File "./src/scripts/generate_abbrev.qx.py", line 65, in <module>
    main()
  File "./src/scripts/generate_abbrev.qx.py", line 58, in main
    qx = generate_qx(data)
  File "./src/scripts/generate_abbrev.qx.py", line 48, in generate_qx
    abbrevs = get_abbrevs(data)
  File "./src/scripts/generate_abbrev.qx.py", line 34, in get_abbrevs
    abbrevs = [ x.rstrip() for x in data if not x.startswith('#') ]
  File "./src/scripts/generate_abbrev.qx.py", line 34, in <listcomp>
    abbrevs = [ x.rstrip() for x in data if not x.startswith('#') ]
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 80: ordinal not in range(128)
Makefile:199: recipe for target 'tmp/abbrev.qx' failed
make[1]: *** [tmp/abbrev.qx] Error 1
```

and also this:
```
...
Traceback (most recent call last):
  File "./src/scripts/test.tmpl2cpp.py", line 152, in <module>
    main()
  File "./src/scripts/test.tmpl2cpp.py", line 118, in main
    tests = [ generate_tests(x) for x in DATA_FILES ]
  File "./src/scripts/test.tmpl2cpp.py", line 118, in <listcomp>
    tests = [ generate_tests(x) for x in DATA_FILES ]
  File "./src/scripts/test.tmpl2cpp.py", line 85, in generate_tests
    fst_line = file_.readline()
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 23: ordinal not in range(128)
```
