### PR TITLE
Add WSAFTER field for case sentence end without WS

### DIFF
--- a/src/quex_modules/convtsv.qx
+++ b/src/quex_modules/convtsv.qx
@@ -52,16 +52,20 @@ mode PROGRAM {
     }
 
     // mondat vege (ws nelkul)
-    {SNT_CLOSE_QX}       { // EOF
-        // std::wcerr << L"PROGRAM: SNTEND + EOF" << std::endl;
-        self_send1(QUEX_TKN_ANYCHAR, L"\n");
-    }
     {SNT_CLOSE_QX}/.       {
         // std::wcerr << L"PROGRAM: SNTEND ..." << std::endl;
         self_send1(QUEX_TKN_ANYCHAR, L"\"\"\n\n");
     }
     {SNT_CLOSE_QX}$       {
         // std::wcerr << L"PROGRAM: SNTEND + $" << std::endl;
+        self_send1(QUEX_TKN_ANYCHAR, L"\"\"\n\n");
+    }
+    {TAGGED_WS_SEQ}/{SNT_CLOSE_QX}{WSPACE}*/       {
+        // std::wcerr << L"PROGRAM: {TAGGED_WS_SEQ}/ SNTEND {WSPACE}*" << std::endl;
+        self_send1(QUEX_TKN_ANYCHAR, L"\n");
+    }
+    {SNT_CLOSE_QX}{WSPACE}*       { // EOF
+        // std::wcerr << L"PROGRAM: SNTEND + EOF" << std::endl;
         self_send1(QUEX_TKN_ANYCHAR, L"\"\"\n\n");
     }
 
@@ -83,7 +87,7 @@ mode PROGRAM {
 }
 
 mode WSHACK {
-    {TAGGED_WS_SEQ}{SNT_CLOSE_QX} {
+    {TAGGED_WS_SEQ}{SNT_CLOSE_QX}/{TAGGED_WS_SEQ} {
         // std::wcerr << L"WSHACK: TAGGED_WS_SEQ + SNT_CLOSE_QX" << std::endl;
         self_send1(QUEX_TKN_ANYCHAR, L"\"");
         std::wstring LEX(LexemeBegin+1, LexemeEnd -2);
@@ -95,6 +99,7 @@ mode WSHACK {
         // std::wcerr << L"WSHACK: TAGGED_WS_SEQ" << std::endl;
         std::wstring LEX(LexemeBegin+1, LexemeEnd -1);
         self.escape_ws(LEX);
+        self_send1(QUEX_TKN_ANYCHAR, LEX.c_str());
         self_send1(QUEX_TKN_ANYCHAR, L"\"\n\n");
         self << PROGRAM;
     }


### PR DESCRIPTION
Without any global knowledge of the inner-workings of Quntoken I think this patch would fix the bug occuring when there is no whitespace on the end of the input text when using the TSV output format.

I have identified eight possible outcomes over three features (a punct/word is followed by zero/more space an zero/more newlines):

1. `echo -n 'A sent ends with punct.'` -> Should yield "" at the end.
2. `echo -n 'A sent ends with word'` -> Should yield "" at the end.
3. `echo -n 'A sent ends with punct and space. '` -> Should yield " " at the end.
4. `echo -n 'A sent ends with word and space '` -> Should yield " " at the end.
5. `echo 'A sent ends with punct and newline.'` -> Should yield "\n" at the end.
6. `echo 'A sent ends with word and newline'` -> Should yield "\n" at the end.
7. `echo 'A sent ends with punct, space and newline '` -> Should yield " \n" at the end.
8. `echo 'A sent ends with word, space and newline '` -> Should yield " \n" at the end.

The rest of the output should be identical. It may be useful to add these cases to the tests.
With this patch all cases above are handled correctly.

Please review and merge.
