### PR TITLE
Add option to print untokenized sentence as CoNLL text meta field

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ Optional arguments:
 
 ```txt
   -h, --help            show this help message and exit
-  -f {tsv,raw,spl,json,xml}, --form {tsv,raw,spl,json,xml}
+  -f {json,raw,spl,tsv,xml}, --form {json,raw,spl,tsv,xml}
                         Valid formats: json, tsv, xml and spl (sentence per
-                        line). Default format: tsv.
+                        line, ignores mode). Default format: tsv.
   -m {sentence,token}, --mode {sentence,token}
-                        Modes: sentence and token. Default: token
+                        Modes: sentence or token (does not apply for
+                        form=spl). Default: token
   -c, --conll-text      Add CoNLL text metafield to contain the detokenized
                         sentence (only for mode == token and format == tsv).
                         Default: False
@@ -65,7 +66,7 @@ word_break=False, w_conll_text_meta_field=False*)
 >- *form*: Format of output. Valid formats: `'tsv'` (default), `'json'`, `'xml'`
 >and `'spl'` (sentence per line).
 >- *mode*: `'sentence'` (only sentence segmenting) or `'token'` (full
->tokenization - default).
+>tokenization - default, does not apply for `form=spl`).
 >- *word_break*: If `True`, eliminates word break from end of lines. Default:
 >`False`.
 >- *w_conll_text_meta_field*: If `True`, add CoNLL text metafield to contain the detokenized

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Optional arguments:
 ### Python API
 
 quntoken.**tokenize**(*inp=sys.stdin, form='tsv', mode='token',
-word_break=False, w_conll_text_meta_field=False*)
+word_break=False, conll_text=False*)
  
 >Entry point, returns an iterator object. Parameters:
 >
@@ -69,7 +69,7 @@ word_break=False, w_conll_text_meta_field=False*)
 >tokenization - default, does not apply for `form=spl`).
 >- *word_break*: If `True`, eliminates word break from end of lines. Default:
 >`False`.
->- *w_conll_text_meta_field*: If `True`, add CoNLL text metafield to contain the detokenized
+>- *conll_text*: If `True`, add CoNLL text metafield to contain the detokenized
 >sentence (Only for mode == token and format == tsv). Default:
 >`False`.
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,14 @@ Optional arguments:
 
 ```txt
   -h, --help            show this help message and exit
-  -f FORM, --form FORM  Valid formats: json, tsv, xml and spl (sentence per
+  -f {tsv,raw,spl,json,xml}, --form {tsv,raw,spl,json,xml}
+                        Valid formats: json, tsv, xml and spl (sentence per
                         line). Default format: tsv.
-  -m MODE, --mode MODE  Modes: sentence or token. Default: token
+  -m {sentence,token}, --mode {sentence,token}
+                        Modes: sentence and token. Default: token
+  -c, --conll-text      Add CoNLL text metafield to contain the detokenized
+                        sentence (only for mode == token and format == tsv).
+                        Default: False
   -w, --word-break      Eliminate word break from end of lines.
   -v, --version         show program's version number and exit
 ```
@@ -52,7 +57,7 @@ Optional arguments:
 ### Python API
 
 quntoken.**tokenize**(*inp=sys.stdin, form='tsv', mode='token',
-word_break=False*)
+word_break=False, w_conll_text_meta_field=False*)
  
 >Entry point, returns an iterator object. Parameters:
 >
@@ -61,8 +66,11 @@ word_break=False*)
 >and `'spl'` (sentence per line).
 >- *mode*: `'sentence'` (only sentence segmenting) or `'token'` (full
 >tokenization - default).
->- *word_break*: If `'True'`, eliminates word break from end of lines. Default:
->`'False'`.
+>- *word_break*: If `True`, eliminates word break from end of lines. Default:
+>`False`.
+>- *w_conll_text_meta_field*: If `True`, add CoNLL text metafield to contain the detokenized
+>sentence (Only for mode == token and format == tsv). Default:
+>`False`.
 
 Example:
 

--- a/quntoken/__main__.py
+++ b/quntoken/__main__.py
@@ -35,7 +35,6 @@ def get_args():
             '--conll-text',
             help='Add CoNLL text metafield to contain the detokenized sentence '
                  '(only for mode == token and format == tsv). Default: False',
-            dest='w_conll_text_meta_field',
             default=False,
             action='store_true'
         )
@@ -52,7 +51,7 @@ def get_args():
         version=__version__
     )
     res = vars(pars.parse_args())
-    if res['w_conll_text_meta_field'] and (res['mode'] != 'token' or res['form'] != 'tsv'):
+    if res['conll_text'] and (res['mode'] != 'token' or res['form'] != 'tsv'):
         raise argparse.ArgumentError(conll_text_arg, 'can only be set if mode == token and form == tsv !')
 
     return res

--- a/quntoken/__main__.py
+++ b/quntoken/__main__.py
@@ -18,16 +18,16 @@ def get_args():
     pars.add_argument(
         '-f',
         '--form',
-        help='Valid formats: json, tsv, xml and spl (sentence per line). Default format: tsv.',
+        help='Valid formats: json, tsv, xml and spl (sentence per line, ignores mode). Default format: tsv.',
         default='tsv',
-        choices=FORMATS
+        choices=sorted(FORMATS)
     )
     pars.add_argument(
         '-m',
         '--mode',
-        help='Modes: sentence and token. Default: token',
+        help='Modes: sentence or token (does not apply for form=spl). Default: token',
         default='token',
-        choices=MODES
+        choices=sorted(MODES)
     )
     conll_text_arg = \
         pars.add_argument(

--- a/quntoken/__main__.py
+++ b/quntoken/__main__.py
@@ -2,29 +2,13 @@ try:
     from quntoken.version import __version__
 except ModuleNotFoundError:
     from version import __version__
-from quntoken import tokenize #, __version__
+from quntoken import tokenize  # , __version__
 # import quntoken
 import argparse
 import sys
 
 FORMATS = {'json', 'raw', 'tsv', 'xml', 'spl'}
 MODES = {'sentence', 'token'}
-
-
-def check_format(form):
-    """Check format argument.
-    """
-    if form not in FORMATS:
-        raise argparse.ArgumentError
-    return form
-
-
-def check_mode(mode):
-    """Check mode argument.
-    """
-    if mode not in MODES:
-        raise argparse.ArgumentError
-    return mode
 
 
 def get_args():
@@ -34,17 +18,27 @@ def get_args():
     pars.add_argument(
         '-f',
         '--form',
-        help= 'Valid formats: json, tsv, xml and spl (sentence per line). Default format: tsv.',
+        help='Valid formats: json, tsv, xml and spl (sentence per line). Default format: tsv.',
         default='tsv',
-        type=check_format
+        choices=FORMATS
     )
     pars.add_argument(
         '-m',
         '--mode',
-        help= 'Modes: sentence and token. Default: token',
+        help='Modes: sentence and token. Default: token',
         default='token',
-        type=check_mode
+        choices=MODES
     )
+    conll_text_arg = \
+        pars.add_argument(
+            '-c',
+            '--conll-text',
+            help='Add CoNLL text metafield to contain the detokenized sentence '
+                 '(only for mode == token and format == tsv). Default: False',
+            dest='w_conll_text_meta_field',
+            default=False,
+            action='store_true'
+        )
     pars.add_argument(
         '-w',
         '--word-break',
@@ -58,6 +52,9 @@ def get_args():
         version=__version__
     )
     res = vars(pars.parse_args())
+    if res['w_conll_text_meta_field'] and (res['mode'] != 'token' or res['form'] != 'tsv'):
+        raise argparse.ArgumentError(conll_text_arg, 'can only be set if mode == token and form == tsv !')
+
     return res
 
 
@@ -70,4 +67,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/quntoken/quntoken.py
+++ b/quntoken/quntoken.py
@@ -76,7 +76,7 @@ class EmTokenPy:
     """
     pass_header = True
 
-    def __init__(self, source_fields=None, target_fields=None):
+    def __init__(self, source_fields=None, target_fields=None, w_conll_text_meta_field=False):
 
         # Field names for e-magyar TSV
         if source_fields is None:
@@ -88,10 +88,33 @@ class EmTokenPy:
         self.source_fields = source_fields
         self.target_fields = target_fields
 
+        if w_conll_text_meta_field:
+            self.process_sentence = self.process_sentence_w_conll_text_meta_field
+        else:
+            self.process_sentence = self.process_sentence_tsv
+
     @staticmethod
-    def process_sentence(sen, _=None):
+    def process_sentence_tsv(sen, _=None):
         res = tokenize(sen)
         return res
+
+    @staticmethod
+    def process_sentence_w_conll_text_meta_field(sen, _=None):
+        sent = []
+        sent_orig = []
+        for tok in tokenize(sen):
+            if len(tok) > 1:
+                sent_orig.append(tok)
+                form, wsafter = tok.rstrip().split('\t', maxsplit=1)
+                wsafter = ' ' if len(wsafter) > 2 else ''
+                sent.append(form)
+                sent.append(wsafter)
+            else:
+                yield f'# text = {"".join(sent)}\n'
+                yield from sent_orig
+                sent = []
+                sent_orig = []
+                yield tok
 
     @staticmethod
     def prepare_fields(field_names):

--- a/quntoken/quntoken.py
+++ b/quntoken/quntoken.py
@@ -84,6 +84,7 @@ def tokenize(inp=sys.stdin, form='tsv', mode='token', word_break=False, conll_te
     form -- format of result (tsv, xml, json, raw)
     mode -- token (tokenization, default) or sentence (just sentence segmenting)
     word_break -- eliminate word break from end of lines (default: False)
+    conll_text -- add CoNLL text metafield to contain the detokenized sentence (default: False)
     """
     modules = get_modules(form, mode, word_break)
     call_modules_fun = call_modules(inp, modules)

--- a/quntoken/quntoken.py
+++ b/quntoken/quntoken.py
@@ -70,7 +70,7 @@ def add_conll_text_meta_field(sen):
             sent.append(wsafter)
 
         else:
-            yield f'# text = {"".join(sent).rstrip()}\n'
+            yield f'# text = {"".join(sent[:-1])}\n'
             yield from sent_orig
             sent = []
             sent_orig = []

--- a/quntoken/quntoken.py
+++ b/quntoken/quntoken.py
@@ -68,15 +68,16 @@ def add_conll_text_meta_field(sen):
             wsafter = ' ' if len(wsafter) > 2 else ''
             sent.append(form)
             sent.append(wsafter)
+
         else:
-            yield f'# text = {"".join(sent)}\n'
+            yield f'# text = {"".join(sent).rstrip()}\n'
             yield from sent_orig
             sent = []
             sent_orig = []
             yield tok
 
 
-def tokenize(inp=sys.stdin, form='tsv', mode='token', word_break=False, w_conll_text_meta_field=False):
+def tokenize(inp=sys.stdin, form='tsv', mode='token', word_break=False, conll_text=False):
     """Entry point, return an iterator object.
 
     inp -- input iterator (default: stdin)
@@ -87,9 +88,9 @@ def tokenize(inp=sys.stdin, form='tsv', mode='token', word_break=False, w_conll_
     modules = get_modules(form, mode, word_break)
     call_modules_fun = call_modules(inp, modules)
 
-    if w_conll_text_meta_field:
+    if conll_text:
         if mode != 'token' or form != 'tsv':
-            raise ValueError('Parameter w_conll_text_meta_field can only be true if mode == token and form == tsv !')
+            raise ValueError('Parameter conll_text can only be true if mode == token and form == tsv !')
         call_modules_fun = add_conll_text_meta_field(call_modules_fun)
 
     return iter(call_modules_fun)
@@ -101,7 +102,7 @@ class EmTokenPy:
     """
     pass_header = True
 
-    def __init__(self, source_fields=None, target_fields=None, w_conll_text_meta_field=False):
+    def __init__(self, source_fields=None, target_fields=None, conll_text=False):
 
         # Field names for e-magyar TSV
         if source_fields is None:
@@ -113,10 +114,10 @@ class EmTokenPy:
         self.source_fields = source_fields
         self.target_fields = target_fields
 
-        self._w_conll_text_meta_field = w_conll_text_meta_field
+        self._conll_text = conll_text
 
     def process_sentence(self, sen, _=None):
-        res = tokenize(sen, w_conll_text_meta_field=self._w_conll_text_meta_field)
+        res = tokenize(sen, conll_text=self._conll_text)
         return res
 
     @staticmethod


### PR DESCRIPTION
The CoNLL format specifies text meta variable to display the
untokenized setence before the vertical format:

```
form	wsafter
# text = This is a sample sentence, but untokenized.
This	" "
is	" "
a	" "
sample	" "
sentence	""
,	" "
but	" "
untokenized	""
.	"\n"

# text = This is another sample sentence untokenized.
This	" "
is	" "
another	" "
sample	" "
sentence	" "
untokenized	""
.	"\n"

```